### PR TITLE
Migrate secrets to macOS Keychain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# YNAB CLI Credentials
+# These are now loaded from macOS Keychain with the "env/" prefix.
+# The keychain entries are:
+#   - env/YNAB_CLI_ACCESS_TOKEN
+#   - env/YNAB_CLI_BUDGET_ID
+#
+# To add to Keychain:
+#   security add-generic-password -a "$USER" -s "env/YNAB_CLI_ACCESS_TOKEN" -w "your_token"
+#   security add-generic-password -a "$USER" -s "env/YNAB_CLI_BUDGET_ID" -w "your_budget_id"
+#
+# For backwards compatibility, you can still use environment variables:
+# YNAB_CLI_ACCESS_TOKEN=your_ynab_access_token
+# YNAB_CLI_BUDGET_ID=your_budget_id

--- a/src/ynab_cli/host/__init__.py
+++ b/src/ynab_cli/host/__init__.py
@@ -1,12 +1,17 @@
 import os
 
 from dotenv import load_dotenv
+from ynab_cli.host.keychain import load_ynab_cli_credentials
 
 cwd = os.getcwd()
 dot_env_path = os.path.join(cwd, ".env")
 
 
 def setup_env() -> None:
+    # First try to load from macOS Keychain
+    load_ynab_cli_credentials()
+
+    # Fall back to .env file for any missing vars
     if os.path.exists(dot_env_path):
         load_dotenv(dot_env_path)
 

--- a/src/ynab_cli/host/keychain.py
+++ b/src/ynab_cli/host/keychain.py
@@ -1,0 +1,45 @@
+"""macOS Keychain utilities for loading secrets."""
+
+import subprocess
+import os
+
+
+def get_keychain_secret(name: str) -> str | None:
+    """
+    Get a secret from macOS Keychain.
+
+    Args:
+        name: The secret name (will be prefixed with "env/")
+
+    Returns:
+        The secret value, or None if not found
+    """
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-a", os.environ.get("USER", ""),
+             "-s", f"env/{name}", "-w"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def load_ynab_cli_credentials() -> None:
+    """
+    Load YNAB CLI credentials from Keychain into environment variables.
+    Falls back to existing env vars if Keychain lookup fails.
+    """
+    credentials = [
+        ("YNAB_CLI_ACCESS_TOKEN", "YNAB_CLI_ACCESS_TOKEN"),
+        ("YNAB_CLI_BUDGET_ID", "YNAB_CLI_BUDGET_ID"),
+    ]
+
+    for env_var, keychain_key in credentials:
+        # Only load from Keychain if env var is not already set
+        if not os.environ.get(env_var):
+            value = get_keychain_secret(keychain_key)
+            if value:
+                os.environ[env_var] = value


### PR DESCRIPTION
## Summary

- Replace dotenv-based credential loading with macOS Keychain for improved security
- Secrets are now stored encrypted (AES-256-GCM) in Keychain with `env/` prefix
- Falls back to .env file if Keychain lookup fails

## Changes

- Add `src/ynab_cli/host/keychain.py` utility for Keychain access
- Update `src/ynab_cli/host/__init__.py` to load from Keychain first
- Add `.env.example` with Keychain setup instructions

## Keychain Entries

| Key | Description |
|-----|-------------|
| `env/YNAB_CLI_ACCESS_TOKEN` | YNAB API access token |
| `env/YNAB_CLI_BUDGET_ID` | YNAB budget ID |

## Test Plan

- [x] Credentials load correctly from Keychain
- [ ] CLI commands work with Keychain-loaded credentials

🤖 Generated with [Claude Code](https://claude.ai/code)