### PR TITLE
fix: Fix unused payees and categories

### DIFF
--- a/src/ynab_cli/domain/use_cases/categories.py
+++ b/src/ynab_cli/domain/use_cases/categories.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from datetime import date
 from typing import TypedDict
 
 from ynab_cli.adapters import ynab
@@ -59,6 +60,7 @@ class ListUnused:
                             settings.ynab.budget_id,
                             str(category.id),
                             client=self._client,
+                            since_date=date(1, 1, 1),
                         )
                     ).data.transactions
                     num_transactions = len(transactions)

--- a/src/ynab_cli/domain/use_cases/payees.py
+++ b/src/ynab_cli/domain/use_cases/payees.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import AsyncIterator
+from datetime import date
 from typing import TypedDict
 from uuid import UUID
 
@@ -200,6 +201,7 @@ class ListUnused:
                         settings.ynab.budget_id,
                         str(payee.id),
                         client=self._client,
+                        since_date=date(1, 1, 1),
                     )
                 ).data.transactions
                 num_transactions = len(transactions)


### PR DESCRIPTION
When getting transactions for a category or payee, if we want all of them then we need to specify a `since_date` otherwise it only gets transactions from the last year.

See [YNAB API v1.85.0](https://api.ynab.com/#v1.85.0)